### PR TITLE
Include alternative certifiate generation script

### DIFF
--- a/Dockerfile.openssl
+++ b/Dockerfile.openssl
@@ -1,0 +1,9 @@
+FROM alpine:3.14
+
+RUN apk update && \
+apk add --no-cache openssl && \
+rm -rf /var/cache/apk/*
+
+COPY generate_key_pair.sh ./
+
+CMD ["./generate_key_pair.sh", "out/"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ You can generate one using
 
 The script requires [`openssl`](https://www.openssl.org/).
 
-## Common Validation Errors
+An alternative script is included which will run openssl in Docker. This can mitigate some openssl
+bug(s) which cause issues with the generated private key in some languages crypto libs.
+
+```bash
+./docker_generate_key_pair.sh
+```
+
+When run, a pair of certificates will appear in `./out`
+
+## Common Problems
+
+### Signature validation
 
 The payload parsed for signing *must* be bytewise equivialent to the payload sent to our API's. The most common cause of issues are errant control characters (often seen in cli implementations where a trailing newline '\n' is inserted/removed).

--- a/docker_generate_key_pair.sh
+++ b/docker_generate_key_pair.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+docker build -t truelayer-cert-gen -f Dockerfile.openssl .
+vol=$(uuidgen)
+docker volume create "${vol}"
+docker run -v "${vol}:/out" truelayer-cert-gen
+cid=$(docker ps -aq -n 1)
+rm -rf out || return
+mkdir -p out
+docker cp ${cid}:/out/ .

--- a/generate_key_pair.sh
+++ b/generate_key_pair.sh
@@ -1,5 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Generate private key
-openssl ecparam -genkey -name secp521r1 -noout -out ec512-private-key.pem
+DIR=${1:-./}
+openssl ecparam -genkey -name secp521r1 -noout -out "${DIR}ec512-private-key.pem"
 # Extract public key
-openssl ec -in ec512-private-key.pem -pubout -out ec512-public-key.pem
+openssl ec -in "${DIR}ec512-private-key.pem" -pubout -out "${DIR}ec512-public-key.pem"


### PR DESCRIPTION
This commit introduces an alternative certificate generation mechanism
using a fixed openssl version in a docker image.

Some clients report issues using the generated EC certs and this is almost
always due to the version of openssl they have installed. Rather that
suggest modifying this, suggest they use different script which should
result in reliable output.
